### PR TITLE
Unpin the inflection dependency

### DIFF
--- a/invoiced/version.py
+++ b/invoiced/version.py
@@ -1,1 +1,1 @@
-VERSION = '2.1.0'
+VERSION = '2.1.1'

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ setup(
     packages=['invoiced', 'invoiced.test'],
     install_requires=[
         'requests >= 2.0.0',
-        'inflection == 0.3.1'
+        'inflection >= 0.3.1'
     ],
     extras_require={
         'requests': ['security>=2.0.0']


### PR DESCRIPTION
The most recent version `inflection` dependency of this library is `0.5.1`, but this library is pinned to `0.3.1`, which is 5.31 years older than the most recent release.

The release notes since `0.3.1` have one breaking change of the `inflection` library, to drop support for older versions of Python. If you don't require users to upgrade their version of inflection, this won't require a major version bump under semver. Since there are no code changes, a patch version bump should be sufficient.

Unpin the dependency so that you won't need to make further releases unless and until inflection breaks in a way that is incompatible with this library.